### PR TITLE
feat: Adds useMessageFormat hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,26 @@ $ yarn add @oursky/react-messageformat
 ```typescript
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { LocaleProvider, FormattedMessage } from "@oursky/react-messageformat";
+import { LocaleProvider, FormattedMessage, useMessageFormat } from "@oursky/react-messageformat";
 
 const MESSAGES = {
   "my.message": "Hello World",
+  "delete_account.placeholder": "Please enter `{NAME}` to delete acount",
 };
 
 function Page() {
+  const messageFormat = useMessageFormat();
+
+  const placeholder = messageFormat.renderToString(
+    'delete_account.placeholder',
+    { NAME: 'nobody' }
+  );
+
   return (
-    <FormattedMessage id="my.message" />
+    <div>
+      <FormattedMessage id="my.message" />
+      <input placeholder={placeholder} />
+    </div>
   );
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,3 +77,10 @@ export const Context: React.Context<ContextValue>;
 export class LocaleProvider extends React.Component<LocaleProviderProps> {}
 export class Consumer extends React.Component<ConsumerProps> {}
 export class FormattedMessage extends React.Component<FormattedMessageProps> {}
+export function useMessageFormat(props?: Omit<FormattedMessageProps, "id">): ContextValue & {
+  compile: (
+    id: string,
+    values?: Values,
+    components?: Components,
+  ) => React.ReactNode;
+};

--- a/src/__tests__/__snapshots__/react.test.tsx.snap
+++ b/src/__tests__/__snapshots__/react.test.tsx.snap
@@ -25,6 +25,31 @@ Array [
 ]
 `;
 
+exports[`Hook with React Element 1`] = `
+Array [
+  "Hello world",
+  " ",
+  "AnyComponent",
+  " ",
+  "I meet ",
+  "John",
+  " ",
+  "ichi",
+  "This is a ",
+  <a
+    href="https://www.example.com"
+  >
+    link
+  </a>,
+]
+`;
+
+exports[`Hook with plain string 1`] = `
+<input
+  value="Hello world"
+/>
+`;
+
 exports[`React Element as value 1`] = `
 Array [
   "Hello world",

--- a/src/__tests__/react.test.tsx
+++ b/src/__tests__/react.test.tsx
@@ -5,6 +5,7 @@ import {
   Context,
   FormattedMessage,
   MessageOwnProps,
+  useMessageFormat,
 } from "../react";
 
 const locale = "en";
@@ -33,6 +34,18 @@ function Input(props: MessageOwnProps) {
       }}
     </Context.Consumer>
   );
+}
+
+function UseMessageFormatPlainString(props: MessageOwnProps) {
+  const messageFormat = useMessageFormat();
+
+  return <input value={messageFormat.renderToString(props.id, props.values)} />;
+}
+
+function UseMessageFormatEmbedded(props: MessageOwnProps) {
+  const messageFormat = useMessageFormat();
+
+  return messageFormat.compile(props.id, props.values, props.components);
 }
 
 class AnyComponent extends React.Component {
@@ -154,6 +167,60 @@ test("imperative", () => {
     .create(
       <LocaleProvider locale={locale} messageByID={messageByID}>
         <Input id="plain.string" />
+      </LocaleProvider>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Hook with plain string", () => {
+  const tree = renderer
+    .create(
+      <LocaleProvider locale={locale} messageByID={messageByID}>
+        <UseMessageFormatPlainString id="plain.string" />
+      </LocaleProvider>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test("Hook with React Element", () => {
+  const tree = renderer
+    .create(
+      <LocaleProvider locale={locale} messageByID={messageByID}>
+        <UseMessageFormatEmbedded
+          id="react.element"
+          values={{
+            ANY: <FormattedMessage id="plain.string" />,
+            NESTED: <AnyComponent />,
+            REACT: (
+              <FormattedMessage
+                id="argument"
+                values={{
+                  GUEST: "John",
+                }}
+              />
+            ),
+            ELEMENT: (
+              <FormattedMessage
+                id="plural"
+                values={{
+                  N: 1,
+                }}
+              />
+            ),
+          }}
+        />
+        <UseMessageFormatEmbedded
+          id="react"
+          components={{
+            A: "a",
+          }}
+          values={{
+            SCHEME: "https",
+            HOST: "www.example.com",
+          }}
+        />
       </LocaleProvider>
     )
     .toJSON();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { parse } from "./parse";
 export { evaluate } from "./eval";
-export { Consumer, Context, FormattedMessage, LocaleProvider } from "./react";
+export {
+  Consumer,
+  Context,
+  FormattedMessage,
+  LocaleProvider,
+  useMessageFormat,
+} from "./react";

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -156,3 +156,34 @@ export class FormattedMessage extends React.Component<MessageOwnProps> {
     return <Consumer>{this.renderMessage}</Consumer>;
   }
 }
+
+export function useMessageFormat(props: Omit<MessageOwnProps, "id"> = {}) {
+  const { useState, useContext, useCallback } = React;
+
+  if (!useState) {
+    throw new Error("At least react@16.7 is required to use useMessageFormat");
+  }
+
+  const context = useContext(Context);
+
+  const compile = useCallback(
+    (
+      id: MessageOwnProps["id"],
+      values?: MessageOwnProps["values"],
+      components?: MessageOwnProps["components"]
+    ) => (
+      <FormattedMessage
+        {...props}
+        id={id}
+        values={values || props.values}
+        components={components || props.components}
+      />
+    ),
+    [props, context]
+  );
+
+  return {
+    ...context,
+    compile,
+  };
+}


### PR DESCRIPTION
refs #12 

Changes:

Adds `useMessageFormat` hook function which returns same values as context except `compile` function. `compile` renders `<FormattedMessage />` rather than tokens